### PR TITLE
Added new vendor Aruba

### DIFF
--- a/samples/sample_data.json
+++ b/samples/sample_data.json
@@ -888,6 +888,30 @@
     },
 
     {
+        "raw": "ArubaOS (MODEL: 515), Version 8.6.0.4-8.6.0.4",
+        "vendor": "ARUBA",
+        "os": "ArubaOS",
+        "model": "515",
+        "version": "8.6.0.4-8.6.0.4"
+    },
+
+    {
+        "raw": "ArubaOS (MODEL: Aruba7010), Version 8.3.0.0 (64659)",
+        "vendor": "ARUBA",
+        "os": "ArubaOS",
+        "model": "7010",
+        "version": "8.3.0.0 (64659)"
+    },
+
+    {
+        "raw": "ArubaOS (MODEL: Aruba7210), Version 6.5.1.6 (60228)",
+        "vendor": "ARUBA",
+        "os": "ArubaOS",
+        "model": "7210",
+        "version": "6.5.1.6 (60228)"
+    },
+
+    {
         "raw": "xxxxxxxxxxxxxxx",
         "vendor": "UNKNOWN",
         "os": "UNKNOWN",

--- a/sysdescrparser/aruba.py
+++ b/sysdescrparser/aruba.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+"""sysdescrparser.aruba."""
+
+import re
+from sysdescr import SysDescr
+
+
+# pylint: disable=no-name-in-module
+# pylint: disable=no-member
+class Aruba(SysDescr):
+
+    """Class Aruba.
+
+    This class is only for vendor definition.
+
+    """
+
+    def __init__(self, raw):
+        """Constructor."""
+        super(Aruba, self).__init__(raw)
+        self.vendor = 'ARUBA'
+        self.model = self.UNKNOWN
+        self.os = 'ArubaOS'
+        self.version = self.UNKNOWN
+
+    def parse(self):
+        """Parsing for sysDescr value."""
+        regex = (r'ArubaOS'
+                 r'.* \(MODEL: (?:Aruba)?(.*)\), Version (.*)')
+        pat = re.compile(regex)
+        res = pat.search(self.raw)
+        if res:
+            self.model = res.group(1)
+            self.version = res.group(2)
+            return self
+
+        return False

--- a/sysdescrparser/sysdescrparser.py
+++ b/sysdescrparser/sysdescrparser.py
@@ -8,6 +8,7 @@ import os
 sys.path.append(os.path.dirname(__file__))
 
 # pylint: disable=C0413
+from aruba import Aruba
 from cisco_asa import CiscoASA
 from cisco_ios import CiscoIOS
 from cisco_nxos import CiscoNXOS
@@ -77,7 +78,14 @@ def sysdescrparser(sysdescr):
 
          https://github.com/mtoshi/sysdescrparser/blob/master/README.rst
 
+
     """
+    #
+    # aruba
+    #
+    obj = Aruba(sysdescr)
+    if obj.parse():
+        return obj
     #
     # cisco asa
     #


### PR DESCRIPTION
Added new class Aruba to sysdescrparser folder and its inizialization in sysdescrparser.py

Example:
![aruba_example](https://user-images.githubusercontent.com/79326183/108530784-45876100-72d6-11eb-953b-8e4deeb4f033.png)

Examples Sysdescr:
'ArubaOS (MODEL: 515), Version 8.6.0.4-8.6.0.4'
'ArubaOS (MODEL: Aruba7010), Version 8.3.0.0 (64659)'
'ArubaOS (MODEL: Aruba7210), Version 6.5.1.6 (60228)'
